### PR TITLE
newline, expr-fj fixes

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -88,8 +88,8 @@ def assemble_and_run(input_files, preprocessed_file=None, output_file=None, defi
 def main():
     for test, _input in (('cat', "Hello World!\0"), ('ncat', ''.join(chr(255-ord(c)) for c in 'Flip Jump Rocks!\0')),
                          ('testbit', ''), ('testbit_with_nops', ''), ('mathbit', ''), ('mathvec', ''), ('not', ''),
-                         ('rep', ''), ('ncmp', ''), ('nadd', ''), ('hexprint', '')):
-        # if test != 'hexprint':
+                         ('rep', ''), ('ncmp', ''), ('nadd', ''), ('hexprint', ''), ('simple', '')):
+        # if test != 'simple':
         #     continue
         print(f'running test {test}({_input}):')
         assemble_and_run([f'tests/{test}.fj'], preprocessed_file=f'tests/compiled/{test}__no_macros.fj',

--- a/tests/simple.fj
+++ b/tests/simple.fj
@@ -1,0 +1,7 @@
+.skip
+.not x
+.loop
+
+x:
+    .bit0
+temp: ;


### PR DESCRIPTION
files can end without NL

FJ ops only-flip without ; like:
  IO
  x+47
now get the line number of the op from the expr (instead of fishy ways.