### PR TITLE
refactor current IO as a module

### DIFF
--- a/src/basicio.py
+++ b/src/basicio.py
@@ -1,0 +1,68 @@
+from sys import stdin, stdout
+from serial import Serial
+from time import time
+
+class BasicIO(Serial):
+    class NoMoreInputException(Exception):
+        pass
+
+    def __init__(self, defined_input, output_verbose, verbose):
+        self.output = bytes()
+        self.output_anything_yet = False
+        self.pause_time = 0
+
+        self.defined_input = defined_input
+        self.output_verbose = output_verbose
+        self.verbose = verbose
+
+        self.output_char, self.output_size = 0, 0
+        self.input_char, self.input_size = 0, 0
+
+    def hasBit(self) -> bool:
+        return self.input_size > 0
+
+    def readBit(self) -> bool:
+        if self.input_size == 0:
+            if self.defined_input is None:
+                pause_time_start = time()
+                self.input_char = stdin.buffer.read(1)[0]
+                pause_time += time() - pause_time_start
+            elif len(self.defined_input) > 0:
+                self.input_char = self.defined_input[0]
+                self.defined_input = self.defined_input[1:]
+            else:
+                if self.output_verbose and self.output_anything_yet:
+                    print()
+                raise NoMoreInputException()
+            self.input_size = 8
+
+        bit = self.input_char & 1
+
+        self.input_char = self.input_char >> 1
+        self.input_size -= 1
+
+        return bit
+
+    def canWriteBit(self) -> bool:
+        return True
+
+    def writeBit(self, bit):
+        self.output_char |= bit << self.output_size
+        self.output_byte = bytes([self.output_char])
+        self.output_size += 1
+        if self.output_size == 8:
+            self.output += self.output_byte
+            if self.output_verbose:
+                if self.verbose:
+                    for _ in range(3):
+                        print()
+                    print(f'Outputted Char:  ', end='')
+                    stdout.buffer.write(bytes([self.output_char]))
+                    stdout.flush()
+                    for _ in range(3):
+                        print()
+                else:
+                    stdout.buffer.write(bytes([self.output_char]))
+                    stdout.flush()
+            self.output_anything_yet = True
+            self.output_char, self.output_size = 0, 0

--- a/src/serial.py
+++ b/src/serial.py
@@ -1,0 +1,12 @@
+class Serial:
+    def hasBit(self) -> bool:
+        raise Exception("not implemented")
+
+    def readBit(self) -> bool:
+        raise Exception("not implemented")
+
+    def canWriteBit(self) -> bool:
+        raise Exception("not implemented")
+
+    def writeBit(self, bit):
+        raise Exception("not implemented")


### PR DESCRIPTION
Ref https://github.com/tomhea/flip-jump/discussions/154

Backwards-compatible as long as attachedDevices isn't passed to run()

```
$ pytest --run tests/
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/lem0n/flip-jump
collected 21 items                                                                                                                                                                           

tests/test_fj.py s....................                                                                                                                                                 [100%]

====================================================================================== warnings summary ======================================================================================
tests/conftest.py:97
  /home/lem0n/flip-jump/tests/conftest.py:97: PytestUnknownMarkWarning: Unknown pytest.mark.run - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    params.append(pytest.param(args, marks=pytest.mark.run(order=RUN_ORDER_INDEX)))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 20 passed, 1 skipped, 1 warning in 0.29s ==========================================================================
```