### PR TITLE
stl: doc-comments steering bit.mul/div toward hex equivalents

### DIFF
--- a/flipjump/stl/bit/div.fj
+++ b/flipjump/stl/bit/div.fj
@@ -56,7 +56,7 @@ ns bit {
     //
     // @NOTE: There is a better version: This one is slow, big, and doesn't error on b==0.
     //        Also it supports only one convention for the sign of the reminder.
-    //        For a faster & better division see hex.div, hex.idiv.
+    //        For a faster & better division see hex.div, hex.idiv (require hex.init).
     // q,a,b,r are bit[:n].
     def idiv n, a, b, q, r @ negative_a, negative_b, one_negative, neg_b_1, do_div, neg_b_2, neg_ans, end {
         .mov negative_a, a+dw*(n-1)
@@ -103,7 +103,7 @@ ns bit {
     // @NOTE: this division implementation is WASTEFUL in space, yet saves running time, compared to div_loop.
     //
     // @NOTE: There is a better version: This one is slow, big, and doesn't error on b==0.
-    //        For a faster & better division see hex.div, hex.idiv.
+    //        For a faster & better division see hex.div, hex.idiv (require hex.init).
     // q,a,b,r are bit[:n].
     def div n, a, b, q, r @ Q, R, end {
         .if0 n, b, end
@@ -152,7 +152,7 @@ ns bit {
     //
     // @NOTE: There is a better version: This one is slow, big, and doesn't error on b==0.
     //        Also it supports only one convention for the sign of the reminder.
-    //        For a faster & better division see hex.div, hex.idiv.
+    //        For a faster & better division see hex.div, hex.idiv (require hex.init).
     // q,a,b,r are bit[:n].
     def idiv_loop n, a, b, q, r @ negative_a, negative_b, one_negative, neg_b_1, do_div, neg_b_2, neg_ans, end {
         .mov negative_a, a+dw*(n-1)
@@ -199,7 +199,7 @@ ns bit {
     // @NOTE: this division implementation saves space, yet is slower, compared to div.
     //
     // @NOTE: There is a better version: This one is slow, big, and doesn't error on b==0.
-    //        For a faster division see hex.div, hex.idiv.
+    //        For a faster & better division see hex.div, hex.idiv (require hex.init).
     // q,a,b,r are bit[:n].
     def div_loop n, a, b, q, r @ loop, do_sub, loop_end, after_loop, A, Q, R, i, end {
         .if0 n, b, end

--- a/flipjump/stl/bit/mul.fj
+++ b/flipjump/stl/bit/mul.fj
@@ -21,10 +21,8 @@ ns bit {
     // b is the number of 1-bits in src.
     // @NOTE: this implementation works with both signed and unsigned numbers.
     // @NOTE: this is slower, yet it saves space, compared to the mul macro.
-    // @Assumes: dst and src are NOT the same address. This macro shifts dst left and src
-    //           right in place each iteration; when they alias, the two shifts cancel, src
-    //           never reaches 0, and the loop runs forever. For squaring (dst==src) use the
-    //           mul macro, which handles aliasing safely.
+    // @Assumes: dst and src are NOT the same address (aliasing makes this macro loop forever).
+    //           For squaring (dst==src) use the mul macro, which handles aliasing safely.
     // @NOTE: For a faster multiplication see hex.mul (requires hex.init).
     def mul_loop n, dst, src @ start, after_add, src_copy, res, end {
         .zero n, res

--- a/flipjump/stl/bit/mul.fj
+++ b/flipjump/stl/bit/mul.fj
@@ -21,6 +21,11 @@ ns bit {
     // b is the number of 1-bits in src.
     // @NOTE: this implementation works with both signed and unsigned numbers.
     // @NOTE: this is slower, yet it saves space, compared to the mul macro.
+    // @Assumes: dst and src are NOT the same address. This macro shifts dst left and src
+    //           right in place each iteration; when they alias, the two shifts cancel, src
+    //           never reaches 0, and the loop runs forever. For squaring (dst==src) use the
+    //           mul macro, which handles aliasing safely.
+    // @NOTE: For a faster multiplication see hex.mul (requires hex.init).
     def mul_loop n, dst, src @ start, after_add, src_copy, res, end {
         .zero n, res
         .mov n, src_copy, src
@@ -51,6 +56,8 @@ ns bit {
     // b is the number of 1-bits in src.
     // @NOTE: this implementation works with both signed and unsigned numbers.
     // @NOTE: this is faster, yet WASTEFUL in space, compared to the mul_loop macro.
+    // @NOTE: safe when dst and src are the same address (squaring: dst *= dst), unlike mul_loop.
+    // @NOTE: For a faster multiplication see hex.mul (requires hex.init).
     def mul n, dst, src @ shifted_src, res, end {
         .zero n, res
         .zero n, shifted_src


### PR DESCRIPTION
## Summary

Documentation-only changes (no behavioral change) steering callers from the `bit.*` multiply/divide macros toward the faster `hex.*` equivalents, and warning about an aliasing footgun in `bit.mul_loop`.

### `bit/mul.fj`
- **`mul_loop`**: added `@Assumes: dst and src are NOT the same address`. The body shifts `dst` left and `src` right *in place* every iteration; when they alias, the two shifts cancel, `src` never reaches 0, and **the loop runs forever**. The note points squaring (`dst==src`) at the `mul` macro, which is aliasing-safe.
- **`mul` / `mul_loop`**: note that `hex.mul` is faster (requires `hex.init`).

### `bit/div.fj`
- **`idiv` / `div` / `idiv_loop` / `div_loop`**: the existing "see `hex.div`, `hex.idiv`" notes now also state they `require hex.init`, and `div_loop`'s slightly-drifted wording is normalized to match the other three.

## Verification
- `bit.mul 8, x, x` with `x=6` → `36` (confirms the documented aliasing-safety of `mul`).
- `bit.mul_loop 8, x, x` confirmed to hang (the documented footgun).
- `mul.fj` + `div.fj` still compile + resolve under `--werror`.

> Note: this branch is based on the `bit.mul` compile fix (`5383df5`), which also reaches `main` via the macro-coverage test PR. Once that merges, this PR's diff is purely the doc-comments above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)