### PR TITLE
Add module-level docstrings to flipjump python files

### DIFF
--- a/flipjump/__init__.py
+++ b/flipjump/__init__.py
@@ -1,3 +1,9 @@
+"""
+the flipjump package - a toolchain for the FlipJump esoteric language.
+this top-level module exposes the public API: the assemble/run/debug entry points,
+the high-level convenience functions, and the commonly-used classes and constants.
+"""
+
 from flipjump.flipjump_cli import assemble_run_according_to_cmd_line_args
 from flipjump.flipjump_quickstart import (
     assemble,

--- a/flipjump/__init__.py
+++ b/flipjump/__init__.py
@@ -1,7 +1,8 @@
 """
-the flipjump package - a toolchain for the FlipJump esoteric language.
-this top-level module exposes the public API: the assemble/run/debug entry points,
-the high-level convenience functions, and the commonly-used classes and constants.
+the flipjump package.
+a toolchain for the FlipJump esoteric language. this top-level module exposes the public
+API: the assemble/run/debug entry points, the high-level convenience functions, and the
+commonly-used classes and constants.
 """
 
 from flipjump.flipjump_cli import assemble_run_according_to_cmd_line_args

--- a/flipjump/assembler/__init__.py
+++ b/flipjump/assembler/__init__.py
@@ -1,3 +1,8 @@
+"""
+the assembler subpackage - compiles flipjump source files into a .fjm binary.
+exposes the main assemble() entry point.
+"""
+
 from flipjump.assembler.assembler import assemble
 
 

--- a/flipjump/assembler/__init__.py
+++ b/flipjump/assembler/__init__.py
@@ -1,6 +1,7 @@
 """
-the assembler subpackage - compiles flipjump source files into a .fjm binary.
-exposes the main assemble() entry point.
+the assembler subpackage.
+compiles flipjump source files into a .fjm binary, and exposes the main assemble() entry
+point.
 """
 
 from flipjump.assembler.assembler import assemble

--- a/flipjump/assembler/assembler.py
+++ b/flipjump/assembler/assembler.py
@@ -1,3 +1,10 @@
+"""
+the core assembly pipeline.
+orchestrates the three stages that turn .fj source into a .fjm binary:
+parsing the macro-tree, resolving macros into a flat op-list (the preprocessor),
+and resolving labels into addresses while writing the result with the fjm Writer.
+"""
+
 import dataclasses
 from collections import defaultdict
 from pathlib import Path

--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -1,3 +1,9 @@
+"""
+the flipjump lexer and parser (built on the sly library).
+tokenizes and parses .fj source files into the macro-tree: macro definitions and
+the operations (flips, jumps, labels, etc.) that make up each macro.
+"""
+
 from os import path
 from pathlib import Path
 from typing import Set, List, Tuple, Dict, Union

--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -1,7 +1,7 @@
 """
-the flipjump lexer and parser (built on the sly library).
-tokenizes and parses .fj source files into the macro-tree: macro definitions and
-the operations (flips, jumps, labels, etc.) that make up each macro.
+the flipjump lexer and parser.
+built on the sly library, it tokenizes and parses .fj source files into the macro-tree:
+macro definitions and the operations (flips, jumps, labels, etc.) that make up each macro.
 """
 
 from os import path

--- a/flipjump/assembler/inner_classes/__init__.py
+++ b/flipjump/assembler/inner_classes/__init__.py
@@ -1,6 +1,7 @@
 """
-inner data-structures used by the assembler - the Expr expression-tree and the
-op classes. this subpackage exposes the Expr class.
+the assembler inner-classes subpackage.
+holds the inner data-structures used by the assembler - the Expr expression-tree and the
+op classes - and exposes the Expr class.
 """
 
 from flipjump.assembler.inner_classes.expr import Expr

--- a/flipjump/assembler/inner_classes/__init__.py
+++ b/flipjump/assembler/inner_classes/__init__.py
@@ -1,3 +1,8 @@
+"""
+inner data-structures used by the assembler - the Expr expression-tree and the
+op classes. this subpackage exposes the Expr class.
+"""
+
 from flipjump.assembler.inner_classes.expr import Expr
 
 

--- a/flipjump/assembler/inner_classes/expr.py
+++ b/flipjump/assembler/inner_classes/expr.py
@@ -1,7 +1,8 @@
 """
-the Expr class - an arithmetic expression-tree over numbers and label names.
-supports the flipjump math operators, and evaluates (minimizes) to a number once all
-the labels it references are known/resolved.
+the Expr class.
+an arithmetic expression-tree over numbers and label names. it supports the flipjump math
+operators, and evaluates (minimizes) to a number once all the labels it references are
+known/resolved.
 """
 
 from __future__ import annotations

--- a/flipjump/assembler/inner_classes/expr.py
+++ b/flipjump/assembler/inner_classes/expr.py
@@ -1,3 +1,9 @@
+"""
+the Expr class - an arithmetic expression-tree over numbers and label names.
+supports the flipjump math operators, and evaluates (minimizes) to a number once all
+the labels it references are known/resolved.
+"""
+
 from __future__ import annotations
 
 from operator import mul, add, sub, floordiv, lshift, rshift, mod, xor, or_, and_

--- a/flipjump/assembler/inner_classes/ops.py
+++ b/flipjump/assembler/inner_classes/ops.py
@@ -1,3 +1,9 @@
+"""
+the op (operation) classes produced by the parser and consumed by the assembler -
+FlipJump, WordFlip, Label, Macro, MacroCall, rep, segment/reserve directives, and the
+final-phase ops - together with their flipjump source-code positions.
+"""
+
 from __future__ import annotations
 
 import dataclasses

--- a/flipjump/assembler/inner_classes/ops.py
+++ b/flipjump/assembler/inner_classes/ops.py
@@ -1,7 +1,8 @@
 """
-the op (operation) classes produced by the parser and consumed by the assembler -
-FlipJump, WordFlip, Label, Macro, MacroCall, rep, segment/reserve directives, and the
-final-phase ops - together with their flipjump source-code positions.
+the op (operation) classes.
+the operations produced by the parser and consumed by the assembler - FlipJump, WordFlip,
+Label, Macro, MacroCall, rep, segment/reserve directives, and the final-phase ops -
+together with their flipjump source-code positions.
 """
 
 from __future__ import annotations

--- a/flipjump/assembler/preprocessor.py
+++ b/flipjump/assembler/preprocessor.py
@@ -1,3 +1,9 @@
+"""
+the preprocessor (macro-resolution stage).
+expands macro calls and rep (repetition) blocks recursively, starting from the main
+macro, and produces the flat op-list that the assembler then resolves into addresses.
+"""
+
 from __future__ import annotations
 
 import collections

--- a/flipjump/fjm/__init__.py
+++ b/flipjump/fjm/__init__.py
@@ -1,3 +1,8 @@
+"""
+the fjm subpackage - reading and writing the .fjm (FlipJump Memory) binary file format.
+exposes the FJ_MAGIC constant and the FJMVersion enum.
+"""
+
 from flipjump.fjm.fjm_consts import FJ_MAGIC, FJMVersion
 
 

--- a/flipjump/fjm/__init__.py
+++ b/flipjump/fjm/__init__.py
@@ -1,6 +1,7 @@
 """
-the fjm subpackage - reading and writing the .fjm (FlipJump Memory) binary file format.
-exposes the FJ_MAGIC constant and the FJMVersion enum.
+the fjm subpackage.
+reads and writes the .fjm (FlipJump Memory) binary file format, and exposes the FJ_MAGIC
+constant and the FJMVersion enum.
 """
 
 from flipjump.fjm.fjm_consts import FJ_MAGIC, FJMVersion

--- a/flipjump/fjm/fjm_consts.py
+++ b/flipjump/fjm/fjm_consts.py
@@ -1,3 +1,9 @@
+"""
+constants and definitions for the .fjm (FlipJump Memory) binary file format:
+the magic number, the supported FJMVersion enum, the binary header/segment struct
+layouts, and the LZMA compression settings used by the compressed version.
+"""
+
 import lzma
 from enum import Enum
 from typing import List, Dict

--- a/flipjump/fjm/fjm_consts.py
+++ b/flipjump/fjm/fjm_consts.py
@@ -1,7 +1,8 @@
 """
-constants and definitions for the .fjm (FlipJump Memory) binary file format:
-the magic number, the supported FJMVersion enum, the binary header/segment struct
-layouts, and the LZMA compression settings used by the compressed version.
+the .fjm format constants.
+the constants and definitions for the .fjm (FlipJump Memory) binary file format: the magic
+number, the supported FJMVersion enum, the binary header/segment struct layouts, and the
+LZMA compression settings used by the compressed version.
 """
 
 import lzma

--- a/flipjump/fjm/fjm_reader.py
+++ b/flipjump/fjm/fjm_reader.py
@@ -1,3 +1,9 @@
+"""
+the .fjm file reader.
+parses an .fjm binary's header and segments, decompresses the data when needed, and
+exposes the program as a word-addressable memory dictionary for the interpreter.
+"""
+
 import dataclasses
 import lzma
 import struct

--- a/flipjump/fjm/fjm_writer.py
+++ b/flipjump/fjm/fjm_writer.py
@@ -1,3 +1,10 @@
+"""
+the .fjm file writer.
+writes a compiled flipjump program to an .fjm binary - emitting the header, the data
+and segments, and the metadata (flags) - with support for the different fjm versions
+and optional LZMA compression.
+"""
+
 import lzma
 from pathlib import Path
 from struct import pack

--- a/flipjump/flipjump_cli.py
+++ b/flipjump/flipjump_cli.py
@@ -1,3 +1,9 @@
+"""
+the command-line interface (the `fj` command).
+parses the command-line arguments, prepares temporary files, and drives the
+assemble and/or run flows according to the chosen --asm / --run options.
+"""
+
 import argparse
 import lzma
 import os

--- a/flipjump/flipjump_quickstart.py
+++ b/flipjump/flipjump_quickstart.py
@@ -1,7 +1,8 @@
 """
-the high-level programmatic API for using flipjump from python.
-provides convenience wrappers - assemble, run, debug, run_test_output, and the
-combined assemble_and_run / assemble_and_debug / assemble_and_run_test_output helpers.
+the high-level programmatic API.
+the convenience wrappers for using flipjump from python - assemble, run, debug,
+run_test_output, and the combined assemble_and_run / assemble_and_debug /
+assemble_and_run_test_output helpers.
 """
 
 from pathlib import Path

--- a/flipjump/flipjump_quickstart.py
+++ b/flipjump/flipjump_quickstart.py
@@ -1,3 +1,9 @@
+"""
+the high-level programmatic API for using flipjump from python.
+provides convenience wrappers - assemble, run, debug, run_test_output, and the
+combined assemble_and_run / assemble_and_debug / assemble_and_run_test_output helpers.
+"""
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Set

--- a/flipjump/interpretter/__init__.py
+++ b/flipjump/interpretter/__init__.py
@@ -1,6 +1,7 @@
 """
-the interpretter subpackage - runs (and debugs) compiled .fjm programs.
-exposes the run() entry point and the TerminationStatistics result class.
+the interpreter subpackage.
+runs (and debugs) compiled .fjm programs, and exposes the run() entry point and the
+TerminationStatistics result class.
 """
 
 from flipjump.interpretter.fjm_run import TerminationStatistics, run

--- a/flipjump/interpretter/__init__.py
+++ b/flipjump/interpretter/__init__.py
@@ -1,3 +1,8 @@
+"""
+the interpretter subpackage - runs (and debugs) compiled .fjm programs.
+exposes the run() entry point and the TerminationStatistics result class.
+"""
+
 from flipjump.interpretter.fjm_run import TerminationStatistics, run
 
 

--- a/flipjump/interpretter/debugging/__init__.py
+++ b/flipjump/interpretter/debugging/__init__.py
@@ -1,5 +1,5 @@
 """
-the debugging subpackage - tools used while running a .fjm program:
-breakpoint handling, macro code-usage statistics graphs, and the gui message-boxes
-that drive interactive debugging.
+the debugging subpackage.
+the tools used while running a .fjm program: breakpoint handling, macro code-usage
+statistics graphs, and the gui message-boxes that drive interactive debugging.
 """

--- a/flipjump/interpretter/debugging/__init__.py
+++ b/flipjump/interpretter/debugging/__init__.py
@@ -1,0 +1,5 @@
+"""
+the debugging subpackage - tools used while running a .fjm program:
+breakpoint handling, macro code-usage statistics graphs, and the gui message-boxes
+that drive interactive debugging.
+"""

--- a/flipjump/interpretter/debugging/breakpoints.py
+++ b/flipjump/interpretter/debugging/breakpoints.py
@@ -1,3 +1,9 @@
+"""
+breakpoint handling for the interpreter's debugger.
+resolves breakpoints (by address, exact label, or label-substring), maps addresses
+back to labels, and pauses the run to let the user inspect memory and program state.
+"""
+
 import re
 from pathlib import Path
 from typing import Optional, Dict, Set, Tuple

--- a/flipjump/interpretter/debugging/macro_usage_graph.py
+++ b/flipjump/interpretter/debugging/macro_usage_graph.py
@@ -1,3 +1,9 @@
+"""
+macro code-usage statistics.
+aggregates how much compiled code each macro is responsible for, and renders it as a
+two-level pie chart (using plotly) to highlight where the program's size goes.
+"""
+
 import collections
 from typing import Dict, Tuple, List
 

--- a/flipjump/interpretter/debugging/macro_usage_graph.py
+++ b/flipjump/interpretter/debugging/macro_usage_graph.py
@@ -1,7 +1,7 @@
 """
 macro code-usage statistics.
-aggregates how much compiled code each macro is responsible for, and renders it as a
-two-level pie chart (using plotly) to highlight where the program's size goes.
+aggregates how much compiled code each macro is responsible for, and renders it as a pie
+chart (using plotly) to highlight where the program's size goes.
 """
 
 import collections

--- a/flipjump/interpretter/debugging/message_boxes.py
+++ b/flipjump/interpretter/debugging/message_boxes.py
@@ -1,3 +1,9 @@
+"""
+gui message-boxes for interactive debugging (thin wrappers over the optional easygui
+library). used at breakpoints to show messages and to prompt the user for input/choices,
+with a helpful error if easygui isn't installed.
+"""
+
 from typing import List, Optional
 
 from flipjump.utils.exceptions import FlipJumpMissingImportException

--- a/flipjump/interpretter/debugging/message_boxes.py
+++ b/flipjump/interpretter/debugging/message_boxes.py
@@ -1,7 +1,7 @@
 """
-gui message-boxes for interactive debugging (thin wrappers over the optional easygui
-library). used at breakpoints to show messages and to prompt the user for input/choices,
-with a helpful error if easygui isn't installed.
+gui message-boxes for interactive debugging.
+thin wrappers over the optional easygui library, used at breakpoints to show messages and
+to prompt the user for input/choices, with a helpful error if easygui isn't installed.
 """
 
 from typing import List, Optional

--- a/flipjump/interpretter/fjm_run.py
+++ b/flipjump/interpretter/fjm_run.py
@@ -1,3 +1,10 @@
+"""
+the flipjump interpreter.
+executes a compiled .fjm program one flip-jump op at a time - managing the memory,
+routing input/output through an IODevice, handling breakpoints, detecting termination,
+and collecting run statistics (returned as TerminationStatistics).
+"""
+
 from pathlib import Path
 from typing import Optional, Deque
 

--- a/flipjump/interpretter/io_devices/BrokenIO.py
+++ b/flipjump/interpretter/io_devices/BrokenIO.py
@@ -1,3 +1,9 @@
+"""
+a broken io-device that raises on any io action.
+used to run programs that are expected to perform no input/output - any read or write
+turns into an error.
+"""
+
 from flipjump.interpretter.io_devices.IODevice import IODevice
 from flipjump.utils.exceptions import BrokenIOUsed
 

--- a/flipjump/interpretter/io_devices/FixedIO.py
+++ b/flipjump/interpretter/io_devices/FixedIO.py
@@ -1,3 +1,9 @@
+"""
+a fixed-input io-device (mainly for tests).
+reads input from a pre-supplied bytes buffer and collects the program's output in
+memory (retrievable via get_output) instead of printing it.
+"""
+
 from flipjump.interpretter.io_devices.IODevice import IODevice
 from flipjump.utils.exceptions import IOReadOnEOF, IncompleteOutput
 

--- a/flipjump/interpretter/io_devices/IODevice.py
+++ b/flipjump/interpretter/io_devices/IODevice.py
@@ -1,3 +1,9 @@
+"""
+the abstract IO device interface.
+defines the bit-level read/write contract every io-device implements, so the
+interpreter can stay agnostic of where its input/output actually goes.
+"""
+
 from abc import ABC, abstractmethod
 
 

--- a/flipjump/interpretter/io_devices/StandardIO.py
+++ b/flipjump/interpretter/io_devices/StandardIO.py
@@ -1,7 +1,7 @@
 """
 the standard io-device.
 reads the program's input from stdin and writes its output to stdout (output can be
-silenced via the verbose flag).
+silenced by turning off the output_verbose flag).
 """
 
 from sys import stdin, stdout

--- a/flipjump/interpretter/io_devices/StandardIO.py
+++ b/flipjump/interpretter/io_devices/StandardIO.py
@@ -1,3 +1,9 @@
+"""
+the standard io-device.
+reads the program's input from stdin and writes its output to stdout (output can be
+silenced via the verbose flag).
+"""
+
 from sys import stdin, stdout
 
 from flipjump.interpretter.io_devices.IODevice import IODevice

--- a/flipjump/interpretter/io_devices/__init__.py
+++ b/flipjump/interpretter/io_devices/__init__.py
@@ -1,7 +1,7 @@
 """
-the io_devices subpackage - the input/output backends the interpreter uses.
-exposes the IODevice abstract base class and its implementations:
-BrokenIO, FixedIO, and StandardIO.
+the io_devices subpackage.
+the input/output backends the interpreter uses. exposes the IODevice abstract base class
+and its implementations: BrokenIO, FixedIO, and StandardIO.
 """
 
 from flipjump.interpretter.io_devices.BrokenIO import BrokenIO

--- a/flipjump/interpretter/io_devices/__init__.py
+++ b/flipjump/interpretter/io_devices/__init__.py
@@ -1,3 +1,9 @@
+"""
+the io_devices subpackage - the input/output backends the interpreter uses.
+exposes the IODevice abstract base class and its implementations:
+BrokenIO, FixedIO, and StandardIO.
+"""
+
 from flipjump.interpretter.io_devices.BrokenIO import BrokenIO
 from flipjump.interpretter.io_devices.FixedIO import FixedIO
 from flipjump.interpretter.io_devices.IODevice import IODevice

--- a/flipjump/utils/__init__.py
+++ b/flipjump/utils/__init__.py
@@ -1,7 +1,7 @@
 """
-the utils subpackage - shared helpers used across flipjump: common classes,
-project-wide constants, the exception hierarchy, and utility functions.
-exposes TerminationCause, PrintTimer, and get_stl_paths.
+the utils subpackage.
+shared helpers used across flipjump: common classes, project-wide constants, the exception
+hierarchy, and utility functions. exposes TerminationCause, PrintTimer, and get_stl_paths.
 """
 
 from flipjump.utils.classes import TerminationCause, PrintTimer

--- a/flipjump/utils/__init__.py
+++ b/flipjump/utils/__init__.py
@@ -1,3 +1,9 @@
+"""
+the utils subpackage - shared helpers used across flipjump: common classes,
+project-wide constants, the exception hierarchy, and utility functions.
+exposes TerminationCause, PrintTimer, and get_stl_paths.
+"""
+
 from flipjump.utils.classes import TerminationCause, PrintTimer
 from flipjump.utils.functions import get_stl_paths
 

--- a/flipjump/utils/classes.py
+++ b/flipjump/utils/classes.py
@@ -1,7 +1,8 @@
 """
-shared helper classes: the TerminationCause enum (why a run ended), the PrintTimer
-context-manager for timing and printing code-stage durations, and RunStatistics for
-collecting execution metrics during a run.
+shared helper classes.
+the TerminationCause enum (why a run ended), the PrintTimer context-manager for timing and
+printing code-stage durations, and RunStatistics for collecting execution metrics during a
+run.
 """
 
 from __future__ import annotations

--- a/flipjump/utils/classes.py
+++ b/flipjump/utils/classes.py
@@ -1,3 +1,9 @@
+"""
+shared helper classes: the TerminationCause enum (why a run ended), the PrintTimer
+context-manager for timing and printing code-stage durations, and RunStatistics for
+collecting execution metrics during a run.
+"""
+
 from __future__ import annotations
 
 from collections import deque

--- a/flipjump/utils/constants.py
+++ b/flipjump/utils/constants.py
@@ -1,3 +1,9 @@
+"""
+project-wide constants: the macro/label separator strings and prefixes, debugging
+defaults, the io bytes-encoding, compression settings, and the paths to the bundled
+standard library (stl).
+"""
+
 from __future__ import annotations
 
 import lzma

--- a/flipjump/utils/constants.py
+++ b/flipjump/utils/constants.py
@@ -1,7 +1,7 @@
 """
-project-wide constants: the macro/label separator strings and prefixes, debugging
-defaults, the io bytes-encoding, compression settings, and the paths to the bundled
-standard library (stl).
+project-wide constants.
+the macro/label separator strings and prefixes, debugging defaults, the io bytes-encoding,
+compression settings, and the paths to the bundled standard library (stl).
 """
 
 from __future__ import annotations

--- a/flipjump/utils/exceptions.py
+++ b/flipjump/utils/exceptions.py
@@ -1,3 +1,10 @@
+"""
+the flipjump exception hierarchy.
+defines FlipJumpException and its specific subtypes for the different failure points -
+parsing, preprocessing, assembling, writing the fjm, runtime, and io errors.
+"""
+
+
 class FlipJumpException(Exception):
     pass
 

--- a/flipjump/utils/functions.py
+++ b/flipjump/utils/functions.py
@@ -1,3 +1,9 @@
+"""
+shared utility functions: locating the standard-library files, building the (name, path)
+file-tuples the assembler consumes, and saving/loading the compressed debugging-info
+(label dictionaries) used by the debugger.
+"""
+
 from __future__ import annotations
 
 import json

--- a/flipjump/utils/functions.py
+++ b/flipjump/utils/functions.py
@@ -1,7 +1,8 @@
 """
-shared utility functions: locating the standard-library files, building the (name, path)
-file-tuples the assembler consumes, and saving/loading the compressed debugging-info
-(label dictionaries) used by the debugger.
+shared utility functions.
+locating the standard-library files, building the (name, path) file-tuples the assembler
+consumes, and saving/loading the compressed debugging-info (label dictionaries) used by
+the debugger.
 """
 
 from __future__ import annotations

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,9 @@
+"""
+the flipjump test package.
+registers pytest assert-rewriting for the quickstart module so that assertion failures
+inside the flipjump test-helpers show their detailed mismatch values.
+"""
+
 import pytest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+"""
+pytest configuration for the flipjump test-suite.
+defines the custom command-line options, fixtures, and test-collection logic that build
+the compile-and-run test cases from the CSV test catalogs.
+"""
+
 import argparse
 import csv
 import json

--- a/tests/test_fj.py
+++ b/tests/test_fj.py
@@ -1,3 +1,9 @@
+"""
+the end-to-end flipjump tests.
+assembles and runs the .fj programs listed in the CSV test catalogs, feeding each its
+fixed input and asserting it terminates as expected and produces the expected output.
+"""
+
 from pathlib import Path
 from typing import Optional
 


### PR DESCRIPTION
Add a short module-level docstring summarizing the purpose of each .py file
across the flipjump package and the tests directory, including every __init__.py
(such as the previously-empty interpretter/debugging/__init__.py). Documentation
only - no behavior changes.