### PR TITLE
Fix assembler/runtime implementation bugs found in audit

### DIFF
--- a/flipjump/assembler/assembler.py
+++ b/flipjump/assembler/assembler.py
@@ -243,7 +243,7 @@ def assemble(
     :param show_statistics: if true shows macro-usage statistics
     :param print_time: if true prints the times of each assemble-stage
     :param max_recursion_depth: The compiler supports macros that recursively uses other macros,
-    up to the specified recursion depth. If None: no recursion depth restrictions are applied.
+    up to the specified recursion depth.
     """
     try:
         with PrintTimer('  parsing:         ', print_time=print_time):

--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -317,13 +317,13 @@ class FJParser(sly.Parser):
             syntax_error(
                 lineno,
                 f"In macro {macro_name}:  "
-                f"extern labels can't be regular labels: " + ', '.join(global_labels & regular_labels),
+                f"global labels can't be regular labels: " + ', '.join(global_labels & regular_labels),
             )
         if extern_labels & regular_labels:
             syntax_error(
                 lineno,
                 f"In macro {macro_name}:  "
-                f"global labels can't be regular labels: " + ', '.join(extern_labels & regular_labels),
+                f"extern labels can't be regular labels: " + ', '.join(extern_labels & regular_labels),
             )
 
     def validate_no_unused_labels(

--- a/flipjump/assembler/preprocessor.py
+++ b/flipjump/assembler/preprocessor.py
@@ -72,7 +72,7 @@ class PreprocessorData:
             curr_tree: CurrTree,
             calling_op: Union[MacroCall, RepCall],
             macros: Dict[MacroName, Macro],
-            max_recursion_depth: Optional[int],
+            max_recursion_depth: int,
         ):
             """
             Validates that the called macro exists, and that the macro depth is ok. Updates the curr_tree variable.
@@ -80,7 +80,7 @@ class PreprocessorData:
             @param calling_op: the current macro call (either of type Macro or RepCall).
             @param macros: parser's result; the dictionary from the macro names to the macro declaration
             @param max_recursion_depth: The compiler supports macros that recursively uses other macros,
-            up to the specified recursion depth. If None: no recursion depth restrictions are applied.
+            up to the specified recursion depth.
             """
             self.curr_tree = curr_tree
             self.calling_op = calling_op
@@ -95,7 +95,7 @@ class PreprocessorData:
                     f"macro {macro_name} is used but isn't defined. " f"In {self.calling_op.code_position}.",
                 )
             self.curr_tree.append(self.calling_op)
-            if self.max_recursion_depth is not None and len(self.curr_tree) > self.max_recursion_depth:
+            if len(self.curr_tree) > self.max_recursion_depth:
                 macro_resolve_error(
                     self.curr_tree,
                     "The maximal macro-expansion recursive depth was reached. "
@@ -110,7 +110,7 @@ class PreprocessorData:
         @param memory_width: the memory-width
         @param macros: parser's result; the dictionary from the macro names to the macro declaration
         @param max_recursion_depth: The compiler supports macros that recursively uses other macros,
-        up to the specified recursion depth. If None: no recursion depth restrictions are applied.
+        up to the specified recursion depth.
         """
         self.memory_width = memory_width
         self.macros = macros
@@ -134,8 +134,10 @@ class PreprocessorData:
         self.result_ops.append(first_segment)
 
         self.max_recursion_depth = max_recursion_depth
-        if max_recursion_depth + GAP_BETWEEN_PYTHONS_AND_PREPROCESSOR_MACRO_RECURSION_DEPTH < sys.getrecursionlimit():
-            sys.setrecursionlimit(max_recursion_depth + GAP_BETWEEN_PYTHONS_AND_PREPROCESSOR_MACRO_RECURSION_DEPTH)
+        # set python's recursion-limit so the preprocessor's own depth-check (at max_recursion_depth)
+        #  triggers before python's RecursionError. Set it unconditionally - whether it's higher or lower than the
+        #  current limit - so that raising max_recursion_depth actually allows deeper macro-recursion.
+        sys.setrecursionlimit(max_recursion_depth + GAP_BETWEEN_PYTHONS_AND_PREPROCESSOR_MACRO_RECURSION_DEPTH)
 
     def patch_last_wflip_address(self) -> None:
         self.last_new_segment.wflip_start_address = self.curr_address
@@ -198,6 +200,13 @@ class PreprocessorData:
 
     def align_current_address(self, ops_alignment: int) -> None:
         op_size = 2 * self.memory_width
+        if self.curr_address % op_size != 0:
+            macro_resolve_error(
+                self.curr_tree,
+                f"'pad' requires the current address to be op-aligned (a multiple of 2*w={op_size} bits), "
+                f"but it's currently {self.curr_address} bits "
+                f"(this usually happens after a 'reserve' that isn't 2*w-aligned).",
+            )
         ops_to_pad = (-self.curr_address // op_size) % ops_alignment
         self.curr_address += ops_to_pad * op_size
         self.result_ops.append(Padding(ops_to_pad))
@@ -216,13 +225,19 @@ def get_rep_times(op: RepCall, preprocessor_data: PreprocessorData) -> int:
 
 def get_pad_ops_alignment(op: Pad, preprocessor_data: PreprocessorData) -> int:
     try:
-        return op.calculate_ops_alignment(preprocessor_data.labels)
+        ops_alignment = op.calculate_ops_alignment(preprocessor_data.labels)
     except FlipJumpExprException as e:
         macro_resolve_error(
             preprocessor_data.curr_tree,
             f"Can't evaluate how much to pad in " f"'pad {op.ops_alignment}'. In {op.code_position}.",
             orig_exception=e,
         )
+    if ops_alignment <= 0:
+        macro_resolve_error(
+            preprocessor_data.curr_tree,
+            f"'pad' must get a positive ops-alignment, but got {ops_alignment}. In {op.code_position}.",
+        )
+    return ops_alignment
 
 
 def get_next_segment_start(op: Segment, preprocessor_data: PreprocessorData) -> int:
@@ -368,7 +383,7 @@ def resolve_macros(
     @param macros: parser's result; the dictionary from the macro names to the macro declaration
     @param show_statistics: if True then prints the macro-usage statistics
     @param max_recursion_depth: The compiler supports macros that recursively uses other macros,
-    up to the specified recursion depth. If None: no recursion depth restrictions are applied.
+    up to the specified recursion depth.
     @return: tuple of the queue of ops, and the labels' dictionary
     """
     preprocessor_data = PreprocessorData(memory_width, macros, max_recursion_depth)

--- a/flipjump/assembler/preprocessor.py
+++ b/flipjump/assembler/preprocessor.py
@@ -205,7 +205,7 @@ class PreprocessorData:
                 self.curr_tree,
                 f"'pad' requires the current address to be op-aligned (a multiple of 2*w={op_size} bits), "
                 f"but it's currently {self.curr_address} bits "
-                f"(this usually happens after a 'reserve' that isn't 2*w-aligned).",
+                f"(this usually happens after a 'reserve' or 'segment' that isn't 2*w-aligned).",
             )
         ops_to_pad = (-self.curr_address // op_size) % ops_alignment
         self.curr_address += ops_to_pad * op_size

--- a/flipjump/fjm/fjm_reader.py
+++ b/flipjump/fjm/fjm_reader.py
@@ -88,7 +88,7 @@ class Reader:
         except ValueError:
             raise FlipJumpReadFjmException(
                 f'Error: unsupported version ({version}, this program supports {str(SUPPORTED_VERSIONS_NAMES)}).'
-            )
+            ) from None
         if FJMVersion.BaseVersion == self.version:
             self.flags, self.reserved = 0, 0
         else:

--- a/flipjump/fjm/fjm_reader.py
+++ b/flipjump/fjm/fjm_reader.py
@@ -83,7 +83,12 @@ class Reader:
         self.magic, self.memory_width, version, self.segment_num = unpack(
             _header_base_format, fjm_file.read(_header_base_size)
         )
-        self.version = FJMVersion(version)
+        try:
+            self.version = FJMVersion(version)
+        except ValueError:
+            raise FlipJumpReadFjmException(
+                f'Error: unsupported version ({version}, this program supports {str(SUPPORTED_VERSIONS_NAMES)}).'
+            )
         if FJMVersion.BaseVersion == self.version:
             self.flags, self.reserved = 0, 0
         else:
@@ -133,6 +138,12 @@ class Reader:
 
         self.memory_segments = []
         for segment_start, segment_length, data_start, data_length in segments:
+            # data is laid out as (flip-word, jump-word) op-pairs, so its length must be even
+            #  (the relative-jump reconstruction below relies on this).
+            if data_length % 2 != 0:
+                raise FlipJumpReadFjmException(
+                    f"Bad .fjm file: segment data-length must be even (an integer number of ops), got {data_length}."
+                )
             self.memory_segments.append(
                 MemorySegment(
                     segment_start << (self.memory_width.bit_length() - 1),

--- a/flipjump/flipjump_cli.py
+++ b/flipjump/flipjump_cli.py
@@ -92,14 +92,18 @@ def run(in_fjm_path: Path, debug_file: Optional[Path], args: argparse.Namespace,
     )
 
 
-def get_version(version: Optional[int], is_outfile_specified: bool) -> FJMVersion:
+def get_version(version: Optional[int], is_outfile_specified: bool, error_func: ErrorFunc) -> FJMVersion:
     """
     @param version: the fjm version. if None the default version will be taken.
     @param is_outfile_specified: if True, the default is the compressed-version.
      else, the default is the normal version.
+    @param error_func: the parser's error function (used to report an invalid version).
     @return: the chosen version, or default if not specified.
     """
     if version is not None:
+        if version not in {v.value for v in SUPPORTED_VERSIONS_NAMES}:
+            supported = ', '.join(f"{v.value}: {name}" for v, name in SUPPORTED_VERSIONS_NAMES.items())
+            error_func(f'invalid fjm version {version}. supported versions are: {supported}.')
         return FJMVersion(version)
 
     if is_outfile_specified:
@@ -121,7 +125,7 @@ def assemble(out_fjm_file: Path, debug_file: Optional[Path], args: argparse.Name
     fjm_writer = Writer(
         out_fjm_file,
         args.width,
-        get_version(args.version, args.outfile is not None),
+        get_version(args.version, args.outfile is not None, error_func),
         flags=args.flags,
         lzma_preset=args.lzma_preset,
     )

--- a/flipjump/flipjump_quickstart.py
+++ b/flipjump/flipjump_quickstart.py
@@ -45,7 +45,7 @@ def assemble(
     :param show_statistics: if true shows macro-usage statistics
     :param print_time: if true prints the times of each assemble-stage
     :param max_recursion_depth: The compiler supports macros that recursively uses other macros,
-    up to the specified recursion depth. If None: no recursion depth restrictions are applied.
+    up to the specified recursion depth.
 
     :note: This is a wrapper function to the assembler.assemble() function.
     """


### PR DESCRIPTION
## Summary

An audit of the `flipjump/` Python package (compiler/assembler + interpreter) surfaced a handful of real implementation bugs. This PR fixes them. The compile/run core is otherwise solid — the I/O bit-addressing (`3w+#w` input / `2w,2w+1` output matches the STL), the relative-jump encode/decode round-trip, and the wflip suffix-chain builder all check out.

## Changes

- **Recursion limit (functional):** `preprocessor.py` now sets python's recursion limit to `max_recursion_depth + GAP` **unconditionally**. The previous inverted comparison only ever *lowered* it, so raising `--max_recursion_depth` above the default never took effect — deep-but-legal macro recursion crashed as a python `RecursionError` (swallowed into "...please report this bug").
- **`pad` errors:** explicit, descriptive errors for a non-positive ops-alignment (`pad 0` was a `ZeroDivisionError`) and for a non-op-aligned current address (was a silent half-op offset).
- **Swapped diagnostics:** `fj_parser.py` had the global/regular and extern/regular label-group validation messages swapped relative to their conditions.
- **`.fjm` reader:** rejects segments with an odd data-length, and converts an unknown fjm version into a clean `FlipJumpReadFjmException` instead of a bare `ValueError`.
- **CLI:** `get_version()` reports a friendly error listing supported versions instead of crashing with a `ValueError` on an invalid `-v`.
- **Docs/types:** dropped the unsupported "If None" note for `max_recursion_depth` (it is int-typed) and tightened the matching type-hint/guard.

## Verification

- Targeted repros for each fix (recursion limit raised to 5100 at `md=5000`; `pad 0`; bad/odd fjm; invalid `-v`) — all pass; a normal `hello` program still compiles and outputs correctly.
- Test suite: `--fast` 62 passed; `--medium --hexlib` 112 passed (the `pad`-heavy hex-table STL is the main regression surface).
- Gates (repo-pinned versions): `mypy --strict`, `flake8`, `black 24.8.0` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018oK5jZjmmAZv85nhCdCuHL)_