### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -5,6 +5,8 @@ name: Python package
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tomhea/flip-jump/security/code-scanning/1](https://github.com/tomhea/flip-jump/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define at workflow root (applies to all jobs unless overridden), with `contents: read`, which is sufficient for `actions/checkout@v3` and does not change workflow behavior.

Edit `.github/workflows/poetry-publish.yml` right after the `on:` trigger block (before `jobs:`), adding:

```yml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
