### PR TITLE
fix(lexer): reject invalid string/char escapes instead of crashing or silently mis-decoding

### DIFF
--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -103,12 +103,6 @@ char_escape_dict = {
     '?': 0x3F,
 }
 escape_chars = ''.join(k for k in char_escape_dict)
-# the printable alternative EXCLUDES backslash (0x5C: \x5B is '[', \x5D is ']'), so the only way to
-# match a backslash is via a real escape below. otherwise a backslash matches both [ -~] and the escape
-# alternatives, which (a) lets an invalid escape like "\q" through to get_char_value_and_length (crash /
-# silent mis-decode, since the regex and the decoder then segment the bytes differently) and (b) makes
-# "({char})*" ambiguous on backslash (polynomial backtracking). re.escape makes the literal backslash a
-# real member of the escape class (a bare "[...\...]" would let the \ escape the next char instead).
 char = fr'[\x20-\x5B\x5D-\x7E]|\\[{re.escape(escape_chars)}]|\\[xX][0-9a-fA-F]{{2}}'
 
 number_re = fr"({bin_num})|({hex_num})|('({char})')|({dec_num})"

--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -4,6 +4,7 @@ built on the sly library, it tokenizes and parses .fj source files into the macr
 macro definitions and the operations (flips, jumps, labels, etc.) that make up each macro.
 """
 
+import re
 from os import path
 from pathlib import Path
 from typing import Set, List, Tuple, Dict, Union
@@ -102,7 +103,13 @@ char_escape_dict = {
     '?': 0x3F,
 }
 escape_chars = ''.join(k for k in char_escape_dict)
-char = fr'[ -~]|\\[{escape_chars}]|\\[xX][0-9a-fA-F]{{2}}'
+# the printable alternative EXCLUDES backslash (0x5C: \x5B is '[', \x5D is ']'), so the only way to
+# match a backslash is via a real escape below. otherwise a backslash matches both [ -~] and the escape
+# alternatives, which (a) lets an invalid escape like "\q" through to get_char_value_and_length (crash /
+# silent mis-decode, since the regex and the decoder then segment the bytes differently) and (b) makes
+# "({char})*" ambiguous on backslash (polynomial backtracking). re.escape makes the literal backslash a
+# real member of the escape class (a bare "[...\...]" would let the \ escape the next char instead).
+char = fr'[\x20-\x5B\x5D-\x7E]|\\[{re.escape(escape_chars)}]|\\[xX][0-9a-fA-F]{{2}}'
 
 number_re = fr"({bin_num})|({hex_num})|('({char})')|({dec_num})"
 string_re = fr'"({char})*"'

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -5,6 +5,7 @@ these check the pure tokenization rules: number formats (dec/hex/bin, no octal),
 literals and their escapes, little-endian string packing, and comment handling.
 """
 
+from pathlib import Path
 from typing import List, Tuple
 
 import pytest
@@ -36,7 +37,7 @@ def _tokenize_collecting_errors(text: str) -> Tuple[List[object], bool]:
     # used to format the error message. returns (string token values, errored?).
     fj_parser.error_occurred = False
     fj_parser.all_errors = ''
-    fj_parser.curr_file = '<test>'
+    fj_parser.curr_file = Path('<test>')
     fj_parser.curr_file_short_name = '<test>'
     strings = _strings(text)
     return strings, fj_parser.error_occurred

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -5,11 +5,12 @@ these check the pure tokenization rules: number formats (dec/hex/bin, no octal),
 literals and their escapes, little-endian string packing, and comment handling.
 """
 
-from typing import List
+from typing import List, Tuple
 
 import pytest
 
-from flipjump.assembler.fj_parser import FJLexer, get_char_value_and_length
+import flipjump.assembler.fj_parser as fj_parser
+from flipjump.assembler.fj_parser import FJLexer, char_escape_dict, get_char_value_and_length
 
 
 def _token_values(text: str, wanted_type: str) -> List[object]:
@@ -18,6 +19,27 @@ def _token_values(text: str, wanted_type: str) -> List[object]:
 
 def _numbers(text: str) -> List[object]:
     return _token_values(text, 'NUMBER')
+
+
+def _strings(text: str) -> List[object]:
+    return _token_values(text, 'STRING')
+
+
+def _pack(byte_values: List[int]) -> int:
+    # the lexer packs a string little-endian: first char in the low byte.
+    return sum(value << (8 * i) for i, value in enumerate(byte_values))
+
+
+def _tokenize_collecting_errors(text: str) -> Tuple[List[object], bool]:
+    # error()/all_errors/curr_file are module globals only initialized inside parse_macro_tree; seed them
+    # so a lexer error in a pure-lexer test can't NameError or leak into another. the file name is only
+    # used to format the error message. returns (string token values, errored?).
+    fj_parser.error_occurred = False
+    fj_parser.all_errors = ''
+    fj_parser.curr_file = '<test>'
+    fj_parser.curr_file_short_name = '<test>'
+    strings = _strings(text)
+    return strings, fj_parser.error_occurred
 
 
 @pytest.mark.parametrize(
@@ -68,6 +90,46 @@ def test_string_is_little_endian_packed() -> None:
     # "AB" -> 'A' at bits 0..7, 'B' at bits 8..15 == 0x4241
     string_tokens = _token_values('"AB"', 'STRING')
     assert string_tokens == [0x4241]
+
+
+@pytest.mark.parametrize('escape_char, expected_value', list(char_escape_dict.items()))
+def test_every_escape_key_decodes_in_a_char_literal(escape_char: str, expected_value: int) -> None:
+    # \0 \a \b \e \f \n \r \t \v \\ \' \" \?  -- each must lex and decode to its byte.
+    assert _numbers(f"'\\{escape_char}'") == [expected_value]
+
+
+@pytest.mark.parametrize(
+    'string_literal, expected_bytes',
+    [
+        (r'"\\"', [0x5C]),  # escaped backslash: regressed by the naive fix, must still parse
+        (r'"\""', [0x22]),  # escaped quote
+        (r'"\?"', [0x3F]),  # escaped question-mark
+        (r'"a\tb"', [ord('a'), 0x09, ord('b')]),  # escape between printables
+        (r'"\x41Z"', [0x41, ord('Z')]),  # \xHH followed by a printable, not swallowed
+        (r'"\\x41"', [0x5C, ord('x'), ord('4'), ord('1')]),  # escaped backslash then literal x41
+    ],
+)
+def test_valid_strings_pack_correctly(string_literal: str, expected_bytes: List[int]) -> None:
+    assert _strings(string_literal) == [_pack(expected_bytes)]
+
+
+@pytest.mark.parametrize(
+    'bad_string',
+    [
+        r'"\q"',  # unknown escape, non-hex tail  -- used to crash: int('', 16) ValueError
+        r'"\xZZ"',  # bad hex                      -- used to crash: int('ZZ', 16) ValueError
+        r'"\x4"',  # truncated hex                 -- used to silently decode to 0x04
+        r'"\d41"',  # unknown escape, hex tail     -- used to SILENTLY decode to 0x41 == "A"
+        r'"\g30"',  # unknown escape, hex tail     -- used to SILENTLY decode to 0x30 == "0"
+        '"\\"',  # lone backslash                  -- incomplete escape
+    ],
+)
+def test_invalid_escape_is_rejected_not_miscompiled(bad_string: str) -> None:
+    # the whole point: an invalid escape must NOT crash, and must NOT silently become a wrong byte.
+    # it produces no STRING token and flags a lexer error (-> a clean parse error downstream).
+    strings, errored = _tokenize_collecting_errors(bad_string)
+    assert strings == []
+    assert errored
 
 
 def test_line_comment_is_ignored() -> None:


### PR DESCRIPTION
## Problem

The `char` regex used for string/char literals in `flipjump/assembler/fj_parser.py` had `[ -~]` as its printable alternative, which **includes backslash** (0x5C). So a backslash matched both the printable alternative *and* the `\[...]` / `\[xX]..` escape alternatives. Two consequences:

1. **Invalid escapes were never cleanly rejected** — they were tokenized (the lone `\` matched `[ -~]`), then re-walked by `get_char_value_and_length`, which assumes `\xHH` and runs `int(s[2:4], 16)`. Because the token regex and the decoder segment the bytes *differently*, the outcome was either:
   - an uncaught `ValueError` surfaced to the user as **`FlipJumpAssemblerException: ... please report this bug`** (`"\q"`, `"\xZZ"`), or
   - **a silently wrong byte** — `"\d41"` compiled to `0x41` (`'A'`), `"\x4"` to `0x04` — with no diagnostic at all.
2. **Ambiguous `"({char})*"` on backslash** → polynomial backtracking (what a CodeQL `py/polynomial-redos` rule flags). Low practical severity here since the input is the compiler's own source, but the ambiguity is the same root cause as #1.

There was also a **latent bug masked by the above**: `escape_chars` was interpolated raw into `[{escape_chars}]`, so the `\` escaped the following `'` and a literal backslash was never actually a member of the escape class — the escaped-backslash alternative was dead code, only "working" because `[ -~]` caught backslashes anyway.

## Demonstration (pre-fix)

```
"\d41"  -> 0x41   (== "A", silent)
"\41"   -> 0x01   (silent)
"\x4"   -> 0x04   (silent)
"\q"    -> FlipJumpAssemblerException: ...please report this bug
```

## Fix

Both halves are required — fixing only the printable class regresses valid `"\\"`, because the escape class doesn't actually contain backslash (the masked bug):

1. Exclude backslash from the printable alternative: `[ -~]` → `[\x20-\x5B\x5D-\x7E]`.
2. Build the escape class with `re.escape(escape_chars)` so the literal backslash (and any future class-special key like `]`/`^`/`-`) is a real member.

Now a backslash can only be matched by a *real* escape, so the token regex and `get_char_value_and_length` agree on segmentation. Valid escapes still parse; invalid escapes fail at lex time → a clean `FlipJumpParsingException`, not a crash or a wrong byte.

## Tests (`tests/unit/test_parser.py`)

- every escape key (`\0 \a \b \e \f \n \r \t \v \ \' \" \?`) decodes in a char literal;
- tricky valid strings pack correctly: `"\\"`, `"\""`, `"\?"`, `"a\tb"`, `"\x41Z"`, `"\x41"`;
- invalid escapes (`"\q"`, `"\xZZ"`, `"\x4"`, `"\d41"`, `"\g30"`, lone `"\"`) produce **no STRING token** and flag a lexer error — asserting *rejection*, not merely "doesn't crash" (which was the trap).

**Failing-then-passing evidence:** the 8 new/strengthened assertions fail on the pre-fix parser (`IndexError`/`ValueError`/silent wrong value) and pass with the fix. Full `tests/unit/test_parser.py`: 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)