### PR TITLE
fix(parser): read .fj source as UTF-8 regardless of OS locale

### DIFF
--- a/flipjump/assembler/fj_parser.py
+++ b/flipjump/assembler/fj_parser.py
@@ -896,7 +896,7 @@ def validate_current_file(files_seen: Set[Union[str, Path]]) -> None:
 
 def lex_parse_curr_file(lexer: FJLexer, parser: FJParser) -> None:
     global curr_text, curr_namespace
-    curr_text = curr_file.open('r').read()
+    curr_text = curr_file.open('r', encoding='utf-8').read()
     curr_namespace = []
 
     lex_res = lexer.tokenize(curr_text)

--- a/flipjump_claude_conclusions.md
+++ b/flipjump_claude_conclusions.md
@@ -18,12 +18,3 @@ described limitations that have since been fixed: `bit.mul` (works now),
 "no hex decimal printer" (now `hex.print_dec_uint/int` + `hex.input_dec_uint/int`),
 and the `n`/`i`/`d` naming trap (`rep` iterators are now hygienic; the only
 off-limits names are the `w`/`dw`/`dbit` constants, which the compiler now rejects).
-
-## Residual — not captured anywhere else
-
-- **FIXED: the parser now opens `.fj` source as UTF-8.**
-  `fj_parser.lex_parse_curr_file` was doing `curr_file.open('r').read()` with no
-  `encoding=`, so on a non-UTF-8 Windows locale (e.g. cp1255) a source file
-  containing `√`, `≈`, etc. raised `UnicodeDecodeError`. Now reads with
-  `open('r', encoding='utf-8')`, so `PYTHONUTF8=1` / ASCII-only-source workarounds
-  are no longer required.

--- a/flipjump_claude_conclusions.md
+++ b/flipjump_claude_conclusions.md
@@ -21,9 +21,9 @@ off-limits names are the `w`/`dw`/`dbit` constants, which the compiler now rejec
 
 ## Residual — not captured anywhere else
 
-- **Toolchain TODO: the parser opens `.fj` source with the OS locale codec, not
-  UTF-8.** `fj_parser.lex_parse_curr_file` does `curr_file.open('r').read()` with no
-  `encoding=`, so on a non-UTF-8 Windows locale a source file containing `√`, `≈`,
-  etc. raises `UnicodeDecodeError`. The skill/handoff document the *workaround*
-  (`PYTHONUTF8=1`, or keep source ASCII); the actual one-line *fix* —
-  `open('r', encoding='utf-8')` — has not been made. Worth a small PR.
+- **FIXED: the parser now opens `.fj` source as UTF-8.**
+  `fj_parser.lex_parse_curr_file` was doing `curr_file.open('r').read()` with no
+  `encoding=`, so on a non-UTF-8 Windows locale (e.g. cp1255) a source file
+  containing `√`, `≈`, etc. raised `UnicodeDecodeError`. Now reads with
+  `open('r', encoding='utf-8')`, so `PYTHONUTF8=1` / ASCII-only-source workarounds
+  are no longer required.

--- a/programs/catalog/HANDOFF.md
+++ b/programs/catalog/HANDOFF.md
@@ -61,10 +61,9 @@ Lowest-risk, highest-leverage: the idioms already exist (see Lessons).
 | calendar_time | 2 | dec_year_2digit_to_4digit, days_between_dates_same_year |
 | io | 1 | reverse_line |
 
-> ⚠️ `mersenne_check` was deferred only because its `CATALOG.md` description literally
-> contains `√` and `≈`, which crash the parser under a non-UTF-8 Windows locale (see
-> Lessons → UTF-8). Either run with `PYTHONUTF8=1`, or rephrase the program header to
-> all-ASCII (the spec text in CATALOG.md is the contract, not the header comment).
+> ℹ️ `mersenne_check` was originally deferred because its `CATALOG.md` description
+> contains `√` and `≈`, which crashed the parser under a non-UTF-8 Windows locale. That
+> parser bug is now fixed (source is read as UTF-8), so the constraint no longer applies.
 
 ### Pass 2 — algorithms, data_structures, language_demos (167)
 
@@ -136,7 +135,6 @@ what the skill documents):
   a batch was committed on `main` and the push failed.
 - **Compile cost is flat ~0.18s/program at w=64** (STL macro resolution, not your
   body). ~1200 programs ≈ a few minutes parallel. Keep CSVs sorted slowest-first.
-- **UTF-8 source bug (UNFIXED)**: `fj` opens `.fj` files with the OS locale codec
-  (`fj_parser.lex_parse_curr_file`: `curr_file.open('r').read()`, no `encoding=`). On a
-  non-UTF-8 Windows locale, non-ASCII source chars (`√ ≈ …`) raise `UnicodeDecodeError`.
-  Keep headers ASCII-only, or set `PYTHONUTF8=1`. (A proper fix = open as UTF-8.)
+- **UTF-8 source (FIXED)**: `fj_parser.lex_parse_curr_file` now reads source with
+  `open('r', encoding='utf-8')`, so non-ASCII source chars no longer depend on the OS
+  locale. No `PYTHONUTF8=1` / ASCII-only-header workaround needed anymore.


### PR DESCRIPTION
## Problem

When the assembler reads a `.fj` source file, `fj_parser.lex_parse_curr_file` did:

```python
curr_text = curr_file.open('r').read()
```

`Path.open('r')` with no `encoding=` decodes using the **OS locale codec** (`locale.getencoding()`), not UTF-8. On a non-UTF-8 Windows locale (e.g. cp1252, or cp1255 on a Hebrew system) any `.fj` source containing a non-ASCII byte — a comment with `√`, `≈`, `∞`, `λ`, box-drawing glyphs, emoji, etc. — raises `UnicodeDecodeError` and assembly crashes.

This was previously only papered over with workarounds (`set PYTHONUTF8=1`, or "keep source ASCII-only"); the actual fix had never been made.

## Fix

Pin the source read to UTF-8, the universal source-file convention:

```python
curr_text = curr_file.open('r', encoding='utf-8').read()
```

This is the only place that reads `.fj` text. The other `open()` calls in the package read binary `.fjm`/debug files in `'rb'` mode and are unaffected.

## Verification

Reproduced and confirmed on a cp1255 (Hebrew) Windows locale:

- **Before:** reading a `.fj` file containing `√ ≈ ∞` raised `UnicodeDecodeError`.
- **After:** the file reads cleanly, and a full end-to-end `parse_macro_tree(...)` on the same non-ASCII source parses successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
