### PR TITLE
Fix: fjm reader raises FlipJumpReadFjmException on malformed width/segment

### DIFF
--- a/flipjump/fjm/fjm_consts.py
+++ b/flipjump/fjm/fjm_consts.py
@@ -59,6 +59,8 @@ SUPPORTED_VERSIONS_NAMES = {
     FJMVersion.CompressedVersion: 'Compressed',
 }
 
+SUPPORTED_MEMORY_WIDTHS: frozenset[int] = frozenset({8, 16, 32, 64})
+
 
 _LZMA_FORMAT = lzma.FORMAT_RAW
 _LZMA_DECOMPRESSION_FILTERS: List[Dict[str, int]] = [{"id": lzma.FILTER_LZMA2}]

--- a/flipjump/fjm/fjm_reader.py
+++ b/flipjump/fjm/fjm_reader.py
@@ -24,6 +24,7 @@ from flipjump.fjm.fjm_consts import (
     _segment_format,
     _segment_size,
     SUPPORTED_VERSIONS_NAMES,
+    SUPPORTED_MEMORY_WIDTHS,
     _LZMA_FORMAT,
     _LZMA_DECOMPRESSION_FILTERS,
     _new_garbage_val,
@@ -110,6 +111,11 @@ class Reader:
             raise FlipJumpReadFjmException(
                 f'Error: unsupported version ({self.version}, this program supports {str(SUPPORTED_VERSIONS_NAMES)}).'
             )
+        if self.memory_width not in SUPPORTED_MEMORY_WIDTHS:
+            raise FlipJumpReadFjmException(
+                f'Error: unsupported memory width ({self.memory_width},'
+                f' this program supports {sorted(SUPPORTED_MEMORY_WIDTHS)}).'
+            )
         if self.reserved != 0:
             raise FlipJumpReadFjmException(f'Error: bad reserved value ({self.reserved}, should be 0).')
 
@@ -149,6 +155,11 @@ class Reader:
             if data_length % 2 != 0:
                 raise FlipJumpReadFjmException(
                     f"Bad .fjm file: segment data-length must be even (an integer number of ops), got {data_length}."
+                )
+            if data_start + data_length > len(data):
+                raise FlipJumpReadFjmException(
+                    f"Bad .fjm file: segment data range [{data_start}, {data_start + data_length})"
+                    f" exceeds data pool length {len(data)}."
                 )
             self.memory_segments.append(
                 MemorySegment(

--- a/flipjump/fjm/fjm_writer.py
+++ b/flipjump/fjm/fjm_writer.py
@@ -16,6 +16,7 @@ from flipjump.fjm.fjm_consts import (
     _header_extension_format,
     _segment_format,
     SUPPORTED_VERSIONS_NAMES,
+    SUPPORTED_MEMORY_WIDTHS,
     _LZMA_FORMAT,
     _lzma_compression_filters,
     FJMVersion,
@@ -50,8 +51,8 @@ class Writer:
         @param flags: the file's flags
         @param lzma_preset: the preset to be used when compressing the .fjm data
         """
-        if memory_width not in (8, 16, 32, 64):
-            raise FlipJumpWriteFjmException(f"Word size {memory_width} is not in {{8, 16, 32, 64}}.")
+        if memory_width not in SUPPORTED_MEMORY_WIDTHS:
+            raise FlipJumpWriteFjmException(f"Word size {memory_width} is not in {set(SUPPORTED_MEMORY_WIDTHS)}.")
         if version not in SUPPORTED_VERSIONS_NAMES:
             raise FlipJumpWriteFjmException(
                 f'Error: unsupported version ({version}, this program supports {str(SUPPORTED_VERSIONS_NAMES)}).'

--- a/flipjump/fjm/fjm_writer.py
+++ b/flipjump/fjm/fjm_writer.py
@@ -52,7 +52,7 @@ class Writer:
         @param lzma_preset: the preset to be used when compressing the .fjm data
         """
         if memory_width not in SUPPORTED_MEMORY_WIDTHS:
-            raise FlipJumpWriteFjmException(f"Word size {memory_width} is not in {set(SUPPORTED_MEMORY_WIDTHS)}.")
+            raise FlipJumpWriteFjmException(f"Word size {memory_width} is not in {sorted(SUPPORTED_MEMORY_WIDTHS)}.")
         if version not in SUPPORTED_VERSIONS_NAMES:
             raise FlipJumpWriteFjmException(
                 f'Error: unsupported version ({version}, this program supports {str(SUPPORTED_VERSIONS_NAMES)}).'

--- a/tests/unit/test_fjm.py
+++ b/tests/unit/test_fjm.py
@@ -6,6 +6,7 @@ covers round-trips across all versions and memory-widths, the relative-jump tran
 and reading corrupt files.
 """
 
+import struct
 from pathlib import Path
 from typing import List
 
@@ -183,3 +184,28 @@ def test_read_unsupported_version_raises(tmp_path: Path) -> None:
 
 def test_magic_constant_matches_fj() -> None:
     assert FJ_MAGIC == ord('F') + (ord('J') << 8)
+
+
+# --- malformed-input robustness (security-audit findings) ---
+
+
+def _v1_header(magic: int = FJ_MAGIC, word_size: int = 64, segment_num: int = 0) -> bytes:
+    """Build a raw version-1 (NormalVersion) header with the given fields."""
+    return struct.pack('<HHQQ', magic, word_size, 1, segment_num) + struct.pack('<QL', 0, 0)
+
+
+@pytest.mark.parametrize('bad_width', [0, 3, 7, 12, 24, 33, 128])
+def test_read_unsupported_memory_width_raises(tmp_path: Path, bad_width: int) -> None:
+    bad = tmp_path / 'bad_width.fjm'
+    bad.write_bytes(_v1_header(word_size=bad_width))
+    with pytest.raises(FlipJumpReadFjmException):
+        Reader(bad)
+
+
+def test_read_segment_data_out_of_bounds_raises(tmp_path: Path) -> None:
+    bad = tmp_path / 'bad_seg.fjm'
+    # segment claims 4 words starting at data offset 0, but the data pool is empty
+    segment = struct.pack('<QQQQ', 0, 4, 0, 4)
+    bad.write_bytes(_v1_header(segment_num=1) + segment)
+    with pytest.raises(FlipJumpReadFjmException):
+        Reader(bad)


### PR DESCRIPTION
## Summary

Two malformed-`.fjm` inputs escaped from the Reader as raw Python exceptions
(`KeyError`, `IndexError`) instead of the documented `FlipJumpReadFjmException`.
Found during the pre-1.4.0 security audit.

**Bug 1 — unsupported `memory_width`** (`fjm_reader.py:128`):  
A header with `word_size` not in `{8, 16, 32, 64}` (e.g. 0 or 7) raised
`KeyError` inside `_read_decompressed_data`'s struct-format lookup.
`_validate_header` never checked the width, even though the `Writer` does.

Fix: extract `SUPPORTED_MEMORY_WIDTHS: frozenset[int]` to `fjm_consts.py`,
use it in `_validate_header` (reader) and replace the inline tuple in the
Writer's constructor, keeping both sides in sync from a single source.

**Bug 2 — segment data range out of bounds** (`fjm_reader.py:168`):  
A segment whose `data_start + data_length` exceeds the actual data pool raised
`IndexError` inside `_init_memory`'s copy loop.

Fix: add an explicit `data_start + data_length > len(data)` guard right after
the existing even-length check, raising `FlipJumpReadFjmException` with a
descriptive message before the loop is entered.

## TDD evidence (R1)

### Before (FAIL — 8 new tests, all raising wrong exception type):

```
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[0]   - KeyError: 0
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[3]   - KeyError: 3
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[7]   - KeyError: 7
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[12]  - KeyError: 12
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[24]  - KeyError: 24
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[33]  - KeyError: 33
FAILED tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[128] - KeyError: 128
FAILED tests/unit/test_fjm.py::test_read_segment_data_out_of_bounds_raises    - IndexError: list index out of range
================= 8 failed, 1 passed, 35 deselected in 0.40s ==================
```

### After (44/44 PASS):

```
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[0]   PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[3]   PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[7]   PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[12]  PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[24]  PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[33]  PASSED
tests/unit/test_fjm.py::test_read_unsupported_memory_width_raises[128] PASSED
tests/unit/test_fjm.py::test_read_segment_data_out_of_bounds_raises    PASSED
============================== 44 passed in 0.64s ==============================
```

Full unit suite: **218 passed in 1.98s** (10 files, no failures).

## Integration evidence (R2)

Both bugs are triggered only by malformed `.fjm` files that cannot be produced
by the Writer (which validates widths and segment bounds on its side).
The fix converts raw tracebacks into the `FlipJumpReadFjmException` the caller
already documents. No change to the behavior of valid `.fjm` files.

Proof — running the regular `.fj` integration suite (assemble + run, 84 tests):
```
84 passed in 33.38s
```

## R-by-R self-check

| Rule | Status |
|---|---|
| R1 tests-first evidence | pass |
| R2 integration evidence | pass |
| R3 coverage of touched logic | pass — 8 new tests in `test_fjm.py` |
| R4 resource guard (write) | n/a |
| R5 resource guard (allocation) | n/a |
| R6 module placement | pass — fix is in `flipjump/fjm/`, new constant in `fjm_consts.py` |
| R7 branch + PR naming | pass — `fix/fjm-reader-malformed-input` / `Fix: …` |
| R8 zero new warnings | pass — mypy strict clean, flake8 clean, bandit clean, black clean |

## Test plan

- [x] 218 unit tests pass
- [x] 84 regular `.fj` integration tests pass
- [x] mypy strict / flake8 / bandit / black all clean
- [ ] CR-ist approves